### PR TITLE
allow sphinx docs to be generated & deployed via GitHub button

### DIFF
--- a/.github/workflow/sphinx-docs.yml
+++ b/.github/workflow/sphinx-docs.yml
@@ -1,5 +1,6 @@
 name: Build and Deploy Sphinx Docs
 on:
+  workflow_dispatch: {}
   push:
     branches:
       - main
@@ -36,7 +37,7 @@ jobs:
           touch _build/html/.nojekyll
 
       - name: Deploy to GitHub Pages
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch) && github.ref == 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: docs/_build/html


### PR DESCRIPTION
This PR permits the sphinx docs workflow to be run manually. It will still only deploy to Pages when the "ref" is `main`.

Adding this cuz the last workflow run is in a super random stuck state for weeks now, and I can't trigger a rerun with out this. (That being said, this PR being merged should _also_ trigger a rerun, so :shrug: )