### PR TITLE
Fix typo in GitHub action sphinx-docs.yml

### DIFF
--- a/.github/workflow/sphinx-docs.yml
+++ b/.github/workflow/sphinx-docs.yml
@@ -37,7 +37,7 @@ jobs:
           touch _build/html/.nojekyll
 
       - name: Deploy to GitHub Pages
-        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch) && github.ref == 'refs/heads/main'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: docs/_build/html


### PR DESCRIPTION
I think this typo is why GitHub is failing to run this workflow, and preventing me from running it manually.