### PR TITLE
use expression evaluation syntax for conditional in github action

### DIFF
--- a/.github/workflow/sphinx-docs.yml
+++ b/.github/workflow/sphinx-docs.yml
@@ -37,7 +37,7 @@ jobs:
           touch _build/html/.nojekyll
 
       - name: Deploy to GitHub Pages
-        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+        if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: docs/_build/html


### PR DESCRIPTION
Github has [a special syntax for evaluation expressions](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions); this PR uses it in the conditional for the publishing to pages github action.