### PR TITLE
remove workflow_dispatch event from github action

### DIFF
--- a/.github/workflow/sphinx-docs.yml
+++ b/.github/workflow/sphinx-docs.yml
@@ -1,6 +1,5 @@
 name: Build and Deploy Sphinx Docs
 on:
-  workflow_dispatch: {}
   push:
     branches:
       - main


### PR DESCRIPTION
This PR removes the [`workflow_dispatch`](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch) event from the triggers that can start the documentation workflow. The documentation action hasn't triggered since I added this, and I'm curious if this is the reason why (plus, it's not strictly necessary.)