### PR TITLE
Pydantic v2 upgrade

### DIFF
--- a/pyamplipi/__main__.py
+++ b/pyamplipi/__main__.py
@@ -1179,14 +1179,14 @@ def enable_logging(logconf=None):
 
 
 # helper function to instantiate the client
-def make_amplipi(args: Namespace) -> AmpliPi:
+def make_amplipi(args: Namespace, loop) -> AmpliPi:
     """ Constructs the amplipi client
     """
     endpoint: str = args.amplipi
     timeout: int = args.timeout
     # in shell modus we got frequent server-disconnected-errors - injecting this custom session avoids that
-    connector: TCPConnector = TCPConnector(force_close=True)
-    http_session: ClientSession = ClientSession(connector=connector)
+    connector: TCPConnector = TCPConnector(force_close=True, loop=loop)
+    http_session: ClientSession = ClientSession(connector=connector, loop=loop)
     return AmpliPi(endpoint, timeout=timeout, http_session=http_session)
 
 
@@ -1205,10 +1205,10 @@ def main():
         sys.exit(1)
 
     enable_logging(logconf=args.logconf)
-    amplipi = make_amplipi(args)
 
     # setup async wait construct for main routines
     loop = asyncio.get_event_loop_policy().get_event_loop()
+    amplipi = make_amplipi(args, loop)
     try:
         # trigger the actual called action-function (async) and wait for it
         loop.run_until_complete(

--- a/pyamplipi/__main__.py
+++ b/pyamplipi/__main__.py
@@ -5,13 +5,12 @@ import sys
 import os
 import datetime
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter, Namespace, Action, ArgumentError
+import typing
 from typing import Optional, List, Callable, Sequence, Dict, Any, Union, Type
 from textwrap import indent
-import json
 import yaml
 from pydantic import BaseModel
-from pydantic.fields import ModelField
-from pydantic.main import ModelMetaclass
+from pydantic.fields import FieldInfo
 from dotenv import load_dotenv
 from aiohttp import TCPConnector, ClientSession
 from aiohttp.client_exceptions import ServerDisconnectedError
@@ -26,9 +25,9 @@ from .error import APIError
 # pylint: disable=logging-fstring-interpolation
 
 # constants
-log = logging.getLogger(__name__)                     # central logging channel
-json_ser_kwargs: Dict[str, Any] = dict(
-    exclude_unset=True, indent=2)  # arguments to serialise the json
+log = logging.getLogger(__name__)         # central logging channel
+# arguments to serialise the json
+json_ser_kwargs: Dict[str, Any] = {'exclude_unset': True, 'indent': 2}
 
 
 # text formatters
@@ -44,7 +43,7 @@ def table(d, h) -> str:
 
 # simple list json for List[BaseModel] constructs
 def model_list_to_json(it: Sequence[BaseModel]) -> str:
-    return f"[{','.join([i.json(**json_ser_kwargs) for i in it])}]"
+    return f"[{','.join([i.model_dump_json(**json_ser_kwargs) for i in it])}]"
 
 
 # list methods dumping comprehensive output to stdout
@@ -166,7 +165,7 @@ async def do_status_get(args: Namespace, amplipi: AmpliPi, shell: bool, **kwargs
     """
     log.debug("status.get()")
     status: Status = await amplipi.get_status()
-    write_out(status.json(**json_ser_kwargs), args.outfile)
+    write_out(status.model_dump_json(**json_ser_kwargs), args.outfile)
 
 
 async def do_config_load(args: Namespace, amplipi: AmpliPi, shell: bool, **kwargs):
@@ -227,7 +226,7 @@ async def do_info_get(args: Namespace, amplipi: AmpliPi, shell: bool, **kwargs):
     """
     log.debug("status.info()")
     info: Info = await amplipi.get_info()
-    write_out(info.json(**json_ser_kwargs), args.outfile)
+    write_out(info.model_dump_json(**json_ser_kwargs), args.outfile)
 
 
 # -- source section
@@ -245,7 +244,7 @@ async def do_source_get(args: Namespace, amplipi: AmpliPi, shell: bool, **kwargs
     log.debug(f"source.get({args.sourceid})")
     assert 0 <= args.sourceid <= 3, "source id must be in range 0..3"
     source: Source = await amplipi.get_source(args.sourceid)
-    write_out(source.json(**json_ser_kwargs), args.outfile)
+    write_out(source.model_dump_json(**json_ser_kwargs), args.outfile)
 
 
 async def do_source_getall(args: Namespace, amplipi: AmpliPi, shell: bool, **kwargs):
@@ -297,7 +296,7 @@ async def do_zone_get(args: Namespace, amplipi: AmpliPi, shell: bool, **kwargs):
     log.debug(f"zone.get({args.zoneid})")
     assert 0 <= args.zoneid <= 35, "zone id must be in range 0..35"
     zone: Zone = await amplipi.get_zone(args.zoneid)
-    write_out(zone.json(**json_ser_kwargs), args.outfile)
+    write_out(zone.model_dump_json(**json_ser_kwargs), args.outfile)
 
 
 async def do_zone_getall(args: Namespace, amplipi: AmpliPi, shell: bool, **kwargs):
@@ -348,7 +347,7 @@ async def do_group_get(args: Namespace, amplipi: AmpliPi, shell: bool, **kwargs)
     log.debug(f"group.get({args.groupid})")
     assert 0 <= args.groupid, "group id must be > 0"
     group: Group = await amplipi.get_group(args.groupid)
-    write_out(group.json(**json_ser_kwargs), args.outfile)
+    write_out(group.model_dump_json(**json_ser_kwargs), args.outfile)
 
 
 async def do_group_getall(args: Namespace, amplipi: AmpliPi, shell: bool, **kwargs):
@@ -414,7 +413,7 @@ async def do_stream_get(args: Namespace, amplipi: AmpliPi, shell: bool, **kwargs
     log.debug(f"stream.get({args.streamid})")
     assert 0 <= args.streamid, "stream id must be > 0"
     stream: Stream = await amplipi.get_stream(args.streamid)
-    write_out(stream.json(**json_ser_kwargs), args.outfile)
+    write_out(stream.model_dump_json(**json_ser_kwargs), args.outfile)
 
 
 async def do_stream_getall(args: Namespace, amplipi: AmpliPi, shell: bool, **kwargs):
@@ -529,7 +528,7 @@ async def do_preset_get(args: Namespace, amplipi: AmpliPi, shell: bool, **kwargs
     log.debug(f"preset.get({args.presetid})")
     assert 0 <= args.presetid, "preset id must be > 0"
     preset: Preset = await amplipi.get_preset(args.presetid)
-    write_out(preset.json(**json_ser_kwargs), args.outfile)
+    write_out(preset.model_dump_json(**json_ser_kwargs), args.outfile)
 
 
 async def do_preset_getall(args: Namespace, amplipi: AmpliPi, shell: bool, **kwargs):
@@ -670,7 +669,7 @@ async def shell_cmd_exec(cmdline: str, amplipi: AmpliPi, argsparser: ArgumentPar
         print(e)
 
 
-def instantiate_model(model_cls: ModelMetaclass, infile: str, _input: Optional[Dict[str, Any]] = None,
+def instantiate_model(model_cls, infile: str, _input: Optional[Dict[str, Any]] = None,
                       validate: Optional[Callable] = None):
     """ Instatiates the passed BaseModel based on:
       (1) either the passed input dict (if not None) merged with env var defaults
@@ -688,10 +687,10 @@ def instantiate_model(model_cls: ModelMetaclass, infile: str, _input: Optional[D
             validate(_input)
         return model_cls(**_input)
     #  else read the object from stdin (json)
-    return model_cls.parse_obj(json.loads(read_in(infile)))  # type: ignore
+    return model_cls.model_validate_json(read_in(infile))  # type: ignore
 
 
-def merge_model_kwargs(model_cls: ModelMetaclass, input: dict) -> Dict[str, Any]:
+def merge_model_kwargs(model_cls, _input: dict) -> Dict[str, Any]:
     """ Builds the kwargs needed to construct the passed BaseModel by merging the passed input dict
     with possible available environment variables with key following this pattern:
         "AMPLIPI_" + «name of BaseModel» + "_" + «name of field in BaseModel» (in all caps)
@@ -700,32 +699,40 @@ def merge_model_kwargs(model_cls: ModelMetaclass, input: dict) -> Dict[str, Any]
         envkey = f"AMPLIPI_{model_cls.__name__}_{name}".upper()
         return os.getenv(envkey)
     kwargs = dict()
-    for name, modelfield in model_cls.__fields__.items():  # type: ignore
-        value_str: str = input.get(name, envvar(name))
+    for name, modelfield in model_cls.model_fields.items():  # type: ignore
+        value_str: str = _input.get(name, envvar(name))
         if value_str is not None and isinstance(value_str, str) and len(value_str) > 0:
             value = parse_valuestr(value_str, modelfield)
             log.debug(
-                f"converted {value_str} to {value} for {modelfield.type_}")
+                f"converted {value_str} to {value} for {modelfield.annotation}")
             kwargs[name] = value
     return kwargs
 
 
 # helper functions for the arguments parsing
-def parse_valuestr(val_str: str, modelfield: ModelField):
-    """ Uses the pydantic defined Modelfield to correctly parse CLI passed string-values to typed values
-    Supports simple types and lists of them
+def parse_valuestr(val_str: str, modelfield: FieldInfo):
+    """ Uses the pydantic defined FieldInfo to correctly parse CLI passed string-values to typed values
+    Supports simple types and lists of them which can be wrapped in Optional.
+    TODO: This is fairly fragile. We should find a more robust solution.
     """
-    convertor = modelfield.type_
-    if convertor == bool:
-        def boolconvertor(s):
+    converter: Union[Type, None, Callable] = modelfield.annotation
+
+    if getattr(converter, '_name', None) == "Optional":
+        # Optional needs to be manually unwrapped to the inner type
+        converter = typing.get_args(converter)[0]  # unwrap Optional
+    if converter is bool:
+        def boolconverter(s):
             return len(s) > 0 and s.lower() in ('y', 'yes', '1', 'true', 'on')
-        convertor = boolconvertor
-    if modelfield.outer_type_.__name__ == 'List':
+        converter = boolconverter
+    if converter is list:
         assert val_str[0] == '[' and val_str[-1] == ']', "expected array-value needs to be surrounded with []"
         val_str = val_str[1:-1]
-        return [convertor(v.strip()) for v in val_str.split(',')]
-    # else
-    return convertor(val_str)
+        return [converter(v.strip()) for v in val_str.split(',')]
+    if converter is None:
+        log.warning(
+            f"no converter for {modelfield.title} not converting {val_str}")
+        return val_str
+    return converter(val_str)
 
 
 class ParseDict(Action):
@@ -756,7 +763,7 @@ def add_force_argument(ap: ArgumentParser):
         help="force the command to be executed without interaction.")
 
 
-def add_id_argument(ap: ArgumentParser, model_cls: ModelMetaclass):
+def add_id_argument(ap: ArgumentParser, model_cls):
     """ Adds the --input argument in a consistent way
     """
     name = model_cls.__name__.lower()
@@ -766,7 +773,7 @@ def add_id_argument(ap: ArgumentParser, model_cls: ModelMetaclass):
         help="identifier of the {name} (integer)")
 
 
-def add_input_arguments(ap: ArgumentParser, model_cls: ModelMetaclass, too_complex_for_cli_keyvals: bool = False):
+def add_input_arguments(ap: ArgumentParser, model_cls, too_complex_for_cli_keyvals: bool = False):
     """ Adds the --input -i and --infile -I  argument in a consistent way
     The -i argument takes key-value pairs to construct models rather then provide those in json via stdin (for simple models only)
     The -I argument specifies an input file to use in stead of stdin
@@ -780,7 +787,7 @@ def add_input_arguments(ap: ArgumentParser, model_cls: ModelMetaclass, too_compl
     if too_complex_for_cli_keyvals:
         return
     # else allow key-val --input
-    fields = model_cls.__fields__.keys()  # type: ignore
+    fields = model_cls.model_fields.keys()  # type: ignore
     ap.add_argument(
         '--input', '-i',
         action=ParseDict,

--- a/pyamplipi/amplipi.py
+++ b/pyamplipi/amplipi.py
@@ -452,7 +452,7 @@ class AmpliPi:
         Returns:
             Status: The status of the update operation.
         """
-        response = await self._client.post(f'streams/{stream_id}', update.model_dump_json(**json_ser_kwargs))
+        response = await self._client.patch(f'streams/{stream_id}', update.model_dump_json(**json_ser_kwargs))
         return Status.model_validate(response)
 
     # -- preset calls

--- a/pyamplipi/amplipi.py
+++ b/pyamplipi/amplipi.py
@@ -54,7 +54,7 @@ class AmpliPi:
             Status: The current status of the system.
         """
         response = await self._client.get('')
-        return Status.parse_obj(response)
+        return Status.model_validate(response)
 
     async def load_config(self, config: Config) -> Status:
         """
@@ -66,8 +66,8 @@ class AmpliPi:
         Returns:
             Status: The status of the load operation.
         """
-        response = await self._client.post('load', config.json(**json_ser_kwargs))
-        return Status.parse_obj(response)
+        response = await self._client.post('load', config.model_dump_json(**json_ser_kwargs))
+        return Status.model_validate(response)
 
     async def factory_reset(self) -> Status:
         """
@@ -77,7 +77,7 @@ class AmpliPi:
             Status: The status of the factory reset operation.
         """
         response = await self._client.post('factory_reset')
-        return Status.parse_obj(response)
+        return Status.model_validate(response)
 
     async def system_reset(self) -> Status:
         """
@@ -87,7 +87,7 @@ class AmpliPi:
             Status: The status of the system reset operation.
         """
         response = await self._client.post('reset')
-        return Status.parse_obj(response)
+        return Status.model_validate(response)
 
     async def system_reboot(self) -> Status:
         """
@@ -97,7 +97,7 @@ class AmpliPi:
             Status: The status of the reboot operation.
         """
         response = await self._client.post('reboot')
-        return Status.parse_obj(response)
+        return Status.model_validate(response)
 
     async def system_shutdown(self) -> Status:
         """
@@ -107,7 +107,7 @@ class AmpliPi:
             Status: The status of the shutdown operation.
         """
         response = await self._client.post('shutdown')
-        return Status.parse_obj(response)
+        return Status.model_validate(response)
 
     async def get_info(self) -> Info:
         """
@@ -117,7 +117,7 @@ class AmpliPi:
             Info: Information about the system.
         """
         response = await self._client.get('info')
-        return Info.parse_obj(response)
+        return Info.model_validate(response)
 
     async def get_version(self):
         """
@@ -152,7 +152,7 @@ class AmpliPi:
             List[Source]: A list of available sources.
         """
         response = await self._client.get('sources')
-        return [Source.parse_obj(source) for source in response['sources']]
+        return [Source.model_validate(source) for source in response['sources']]
 
     async def get_source(self, source_id: int) -> Source:
         """
@@ -165,7 +165,7 @@ class AmpliPi:
             Source: The details of the specified source.
         """
         response = await self._client.get(f'sources/{source_id}')
-        return Source.parse_obj(response)
+        return Source.model_validate(response, from_attributes=True)
 
     async def set_source(self, source_id: int, source_update: SourceUpdate) -> Status:
         """
@@ -178,8 +178,8 @@ class AmpliPi:
         Returns:
             Status: The status of the update operation.
         """
-        response = await self._client.patch(f'sources/{source_id}', source_update.json(**json_ser_kwargs))
-        return Status.parse_obj(response)
+        response = await self._client.patch(f'sources/{source_id}', source_update.model_dump_json(**json_ser_kwargs))
+        return Status.model_validate(response)
 
     async def get_source_img(self, source_id: int, height: int, outfile: Optional[str] = None) -> None:
         """
@@ -208,7 +208,7 @@ class AmpliPi:
             Zone: The details of the specified zone.
         """
         response = await self._client.get(f'zones/{zone_id}')
-        return Zone.parse_obj(response)
+        return Zone.model_validate(response)
 
     async def get_zones(self) -> List[Zone]:
         """
@@ -218,7 +218,7 @@ class AmpliPi:
             List[Zone]: A list of available zones.
         """
         response = await self._client.get('zones')
-        return [Zone.parse_obj(zone) for zone in response['zones']]
+        return [Zone.model_validate(zone) for zone in response['zones']]
 
     async def set_zones(self, zone_update: MultiZoneUpdate) -> Status:
         """
@@ -230,8 +230,8 @@ class AmpliPi:
         Returns:
             Status: The status of the update operation.
         """
-        response = await self._client.patch('zones', zone_update.json(**json_ser_kwargs))
-        return Status.parse_obj(response)
+        response = await self._client.patch('zones', zone_update.model_dump_json(**json_ser_kwargs))
+        return Status.model_validate(response)
 
     async def set_zone(self, zone_id: int, zone_update: ZoneUpdate) -> Status:
         """
@@ -245,8 +245,8 @@ class AmpliPi:
             Status: The status of the update operation.
         """
         response = await self._client.patch(f'zones/{zone_id}',
-                                            zone_update.json(**json_ser_kwargs))
-        return Status.parse_obj(response)
+                                            zone_update.model_dump_json(**json_ser_kwargs))
+        return Status.model_validate(response)
 
     # -- group calls
     async def create_group(self, new_group: Group) -> Group:
@@ -259,8 +259,8 @@ class AmpliPi:
         Returns:
             Group: The created group.
         """
-        response = await self._client.post('group', new_group.json(**json_ser_kwargs))
-        return Group.parse_obj(response)
+        response = await self._client.post('group', new_group.model_dump_json(**json_ser_kwargs))
+        return Group.model_validate(response)
 
     async def get_groups(self) -> List[Group]:
         """
@@ -270,7 +270,7 @@ class AmpliPi:
             List[Group]: A list of available groups.
         """
         response = await self._client.get('groups')
-        return [Group.parse_obj(group) for group in response['groups']]
+        return [Group.model_validate(group) for group in response['groups']]
 
     async def get_group(self, group_id) -> Group:
         """
@@ -283,7 +283,7 @@ class AmpliPi:
             Group: The details of the specified group.
         """
         response = await self._client.get(f'groups/{group_id}')
-        return Group.parse_obj(response)
+        return Group.model_validate(response)
 
     async def delete_group(self, group_id):
         """
@@ -296,7 +296,7 @@ class AmpliPi:
             Status: The status of the delete operation.
         """
         response = await self._client.delete(f'groups/{group_id}')
-        return Status.parse_obj(response)
+        return Status.model_validate(response)
 
     async def set_group(self, group_id, update: GroupUpdate) -> Status:
         """
@@ -309,8 +309,8 @@ class AmpliPi:
         Returns:
             Status: The status of the update operation.
         """
-        response = await self._client.patch(f'groups/{group_id}', update.json(**json_ser_kwargs))
-        return Status.parse_obj(response)
+        response = await self._client.patch(f'groups/{group_id}', update.model_dump_json(**json_ser_kwargs))
+        return Status.model_validate(response)
 
     # -- stream calls
     async def get_streams(self) -> List[Stream]:
@@ -321,7 +321,7 @@ class AmpliPi:
             List[Stream]: A list of available streams.
         """
         response = await self._client.get('streams')
-        return [Stream.parse_obj(stream) for stream in response['streams']]
+        return [Stream.model_validate(stream) for stream in response['streams']]
 
     async def get_stream(self, stream_id: int) -> Stream:
         """
@@ -334,7 +334,7 @@ class AmpliPi:
             Stream: The details of the specified stream.
         """
         response = await self._client.get(f'streams/{stream_id}')
-        return Stream.parse_obj(response)
+        return Stream.model_validate(response)
 
     async def play_stream(self, stream_id: int) -> Status:
         """
@@ -347,7 +347,7 @@ class AmpliPi:
             Status: The status of the play operation.
         """
         response = await self._client.post(f'streams/{stream_id}/play')
-        return Status.parse_obj(response)
+        return Status.model_validate(response)
 
     async def pause_stream(self, stream_id: int) -> Status:
         """
@@ -360,7 +360,7 @@ class AmpliPi:
             Status: The status of the pause operation.
         """
         response = await self._client.post(f'streams/{stream_id}/pause')
-        return Status.parse_obj(response)
+        return Status.model_validate(response)
 
     async def previous_stream(self, stream_id: int) -> Status:
         """
@@ -373,7 +373,7 @@ class AmpliPi:
             Status: The status of the previous stream operation.
         """
         response = await self._client.post(f'streams/{stream_id}/prev')
-        return Status.parse_obj(response)
+        return Status.model_validate(response)
 
     async def next_stream(self, stream_id: int) -> Status:
         """
@@ -386,7 +386,7 @@ class AmpliPi:
             Status: The status of the next stream operation.
         """
         response = await self._client.post(f'streams/{stream_id}/next')
-        return Status.parse_obj(response)
+        return Status.model_validate(response)
 
     async def stop_stream(self, stream_id: int) -> Status:
         """
@@ -399,7 +399,7 @@ class AmpliPi:
             Status: The status of the stop operation.
         """
         response = await self._client.post(f'streams/{stream_id}/stop')
-        return Status.parse_obj(response)
+        return Status.model_validate(response)
 
     async def station_change_stream(self, stream_id: int, station: int) -> Status:
         """
@@ -413,7 +413,7 @@ class AmpliPi:
             Status: The status of the station change operation.
         """
         response = await self._client.post(f'streams/{stream_id}/station={station}')
-        return Status.parse_obj(response)
+        return Status.model_validate(response)
 
     async def create_stream(self, new_stream: Stream) -> Status:
         """
@@ -425,8 +425,8 @@ class AmpliPi:
         Returns:
             Status: The status of the create operation.
         """
-        response = await self._client.post('stream', new_stream.json(**json_ser_kwargs))
-        return Status.parse_obj(response)
+        response = await self._client.post('stream', new_stream.model_dump_json(**json_ser_kwargs))
+        return Status.model_validate(response)
 
     async def delete_stream(self, stream_id: int) -> Status:
         """
@@ -439,7 +439,7 @@ class AmpliPi:
             Status: The status of the delete operation.
         """
         response = await self._client.delete(f'streams/{stream_id}')
-        return Status.parse_obj(response)
+        return Status.model_validate(response)
 
     async def set_stream(self, stream_id: int, update: StreamUpdate) -> Status:
         """
@@ -452,8 +452,8 @@ class AmpliPi:
         Returns:
             Status: The status of the update operation.
         """
-        response = await self._client.post(f'streams/{stream_id}', update.json(**json_ser_kwargs))
-        return Status.parse_obj(response)
+        response = await self._client.post(f'streams/{stream_id}', update.model_dump_json(**json_ser_kwargs))
+        return Status.model_validate(response)
 
     # -- preset calls
     async def get_presets(self) -> List[Preset]:
@@ -464,7 +464,7 @@ class AmpliPi:
             List[Preset]: A list of available presets.
         """
         response = await self._client.get('presets')
-        return [Preset.parse_obj(preset) for preset in response['presets']]
+        return [Preset.model_validate(preset) for preset in response['presets']]
 
     async def get_preset(self, preset_id: int) -> Preset:
         """
@@ -477,7 +477,7 @@ class AmpliPi:
             Preset: The details of the specified preset.
         """
         response = await self._client.get(f'presets/{preset_id}')
-        return Preset.parse_obj(response)
+        return Preset.model_validate(response)
 
     async def set_preset(self, preset_id: int, update: PresetUpdate) -> Status:
         """
@@ -490,8 +490,8 @@ class AmpliPi:
         Returns:
             Status: The status of the update operation.
         """
-        response = await self._client.patch(f'presets/{preset_id}', update.json(**json_ser_kwargs))
-        return Status.parse_obj(response)
+        response = await self._client.patch(f'presets/{preset_id}', update.model_dump_json(**json_ser_kwargs))
+        return Status.model_validate(response)
 
     async def create_preset(self, new_preset: Preset) -> Preset:
         """
@@ -503,8 +503,8 @@ class AmpliPi:
         Returns:
             Preset: The created preset.
         """
-        response = await self._client.post('preset', new_preset.json(**json_ser_kwargs))
-        return Preset.parse_obj(response)
+        response = await self._client.post('preset', new_preset.model_dump_json(**json_ser_kwargs))
+        return Preset.model_validate(response)
 
     async def delete_preset(self, preset_id: int) -> Status:
         """
@@ -517,7 +517,7 @@ class AmpliPi:
             Status: The status of the delete operation.
         """
         response = await self._client.delete(f'presets/{preset_id}')
-        return Status.parse_obj(response)
+        return Status.model_validate(response)
 
     async def load_preset(self, preset_id: int) -> Status:
         """
@@ -530,7 +530,7 @@ class AmpliPi:
             Status: The status of the load operation.
         """
         response = await self._client.post(f'presets/{preset_id}/load')
-        return Status.parse_obj(response)
+        return Status.model_validate(response)
 
     # -- anounce call
     async def announce(self, announcement: Announcement, timeout: Optional[int] = None) -> Status:
@@ -544,8 +544,8 @@ class AmpliPi:
         Returns:
             Status: The status of the announcement operation.
         """
-        response = await self._client.post('announce', announcement.json(**json_ser_kwargs), timeout=timeout)
-        return Status.parse_obj(response)
+        response = await self._client.post('announce', announcement.model_dump_json(**json_ser_kwargs), timeout=timeout)
+        return Status.model_validate(response)
 
     # -- play media call
     async def play_media(self, media: PlayMedia) -> Status:
@@ -562,11 +562,11 @@ class AmpliPi:
         if version < MIN_MEDIA_PLAYER_VERSION:  # TOO OLD, USE ANNOUNCEMENT
             announce = Announcement(media=media.media,
                                     source_id=media.source_id)
-            response = await self._client.post('announce', announce.json(**json_ser_kwargs))
-            return Status.parse_obj(response)
+            response = await self._client.post('announce', announce.model_dump_json(**json_ser_kwargs))
+            return Status.model_validate(response)
         else:
-            response = await self._client.post('play', media.json(**json_ser_kwargs))
-            return Status.parse_obj(response)
+            response = await self._client.post('play', media.model_dump_json(**json_ser_kwargs))
+            return Status.model_validate(response)
 
     # -- client control
     async def close(self):

--- a/pyamplipi/models.py
+++ b/pyamplipi/models.py
@@ -9,8 +9,8 @@ from pydantic import BaseModel
 
 class SourceInfo(BaseModel):
     """ Info about the current audio playing from the connected stream (generated during playback) """
-    name: str
-    state: str  # paused, playing, stopped, unknown, loading ???
+    name: Optional[str] = None
+    state: Optional[str] = None  # paused, playing, stopped, ???
     artist: Optional[str] = None
     track: Optional[str] = None
     album: Optional[str] = None

--- a/pyamplipi/models.py
+++ b/pyamplipi/models.py
@@ -121,7 +121,7 @@ class Stream(BaseModel):
 
 class StreamUpdate(BaseModel):
     """ Reconfiguration of a Stream """
-    name: str
+    name: Optional[str] = None
     user: Optional[str] = None
     password: Optional[str] = None
     station: Optional[str] = None

--- a/pyamplipi/models.py
+++ b/pyamplipi/models.py
@@ -8,23 +8,24 @@ from pydantic import BaseModel
 
 
 class SourceInfo(BaseModel):
+    """ Info about the current audio playing from the connected stream (generated during playback) """
     name: str
     state: str  # paused, playing, stopped, unknown, loading ???
-    artist: Optional[str]
-    track: Optional[str]
-    album: Optional[str]
-    station: Optional[str]  # name of radio station
-    img_url: Optional[str]
+    artist: Optional[str] = None
+    track: Optional[str] = None
+    album: Optional[str] = None
+    station: Optional[str] = None  # name of radio station
+    img_url: Optional[str] = None
     supported_cmds: List[str] = []
 
 
 class Source(BaseModel):
     """ An audio source """
-    id: Optional[int]
+    id: Optional[int] = None
     name: str
     input: str
     # Additional info about the current audio playing from the stream (generated during
-    info: Optional[SourceInfo]
+    info: Optional[SourceInfo] = None
     # playback')
 
 
@@ -41,7 +42,7 @@ class SourceUpdateWithId(SourceUpdate):
 
 class Zone(BaseModel):
     """ Audio output to a stereo pair of speakers, typically belonging to a room """
-    id: Optional[int]
+    id: Optional[int] = None
     name: str
     source_id: int
     mute: bool
@@ -54,14 +55,14 @@ class Zone(BaseModel):
 
 class ZoneUpdate(BaseModel):
     """ Reconfiguration of a Zone """
-    name: Optional[str]
-    source_id: Optional[int]
-    mute: Optional[bool]
-    vol: Optional[int]
-    vol_f: Optional[float]
-    vol_min: Optional[int]
-    vol_max: Optional[int]
-    disabled: Optional[bool]
+    name: Optional[str] = None
+    source_id: Optional[int] = None
+    mute: Optional[bool] = None
+    vol: Optional[int] = None
+    vol_f: Optional[float] = None
+    vol_min: Optional[int] = None
+    vol_max: Optional[int] = None
+    disabled: Optional[bool] = None
 
 
 class ZoneUpdateWithId(ZoneUpdate):
@@ -71,31 +72,31 @@ class ZoneUpdateWithId(ZoneUpdate):
 
 class MultiZoneUpdate(BaseModel):
     """ Reconfiguration of multiple zones specified by zone_ids and group_ids """
-    zones: Optional[List[int]]
-    groups: Optional[List[int]]
+    zones: Optional[List[int]] = None
+    groups: Optional[List[int]] = None
     update: ZoneUpdate
 
 
 class Group(BaseModel):
     """ A group of zones that can share the same audio input and be controlled as a group ie. Upstairs. Volume, mute,
     and source_id fields are aggregates of the member zones."""
-    id: Optional[int]
+    id: Optional[int] = None
     name: str
-    source_id: Optional[int]
+    source_id: Optional[int] = None
     zones: List[int]
-    mute: Optional[bool]
-    vol_delta: Optional[int]
-    vol_f: Optional[float]
+    mute: Optional[bool] = None
+    vol_delta: Optional[int] = None
+    vol_f: Optional[float] = None
 
 
 class GroupUpdate(BaseModel):
     """ Reconfiguration of a Group """
-    name: Optional[str]
-    source_id: Optional[int]
-    zones: Optional[List[int]]
-    mute: Optional[bool]
-    vol_delta: Optional[int]
-    vol_f: Optional[float]
+    name: Optional[str] = None
+    source_id: Optional[int] = None
+    zones: Optional[List[int]] = None
+    mute: Optional[bool] = None
+    vol_delta: Optional[int] = None
+    vol_f: Optional[float] = None
 
 
 class GroupUpdateWithId(GroupUpdate):
@@ -105,28 +106,28 @@ class GroupUpdateWithId(GroupUpdate):
 
 class Stream(BaseModel):
     """ Digital stream such as Pandora, AirPlay or Spotify """
-    id: Optional[int]
+    id: Optional[int] = None
     name: str
     type: str
-    user: Optional[str]
-    password: Optional[str]
-    station: Optional[str]
-    url: Optional[str]
-    logo: Optional[str]
-    freq: Optional[str]
-    client_id: Optional[str]
-    token: Optional[str]
+    user: Optional[str] = None
+    password: Optional[str] = None
+    station: Optional[str] = None
+    url: Optional[str] = None
+    logo: Optional[str] = None
+    freq: Optional[str] = None
+    client_id: Optional[str] = None
+    token: Optional[str] = None
 
 
 class StreamUpdate(BaseModel):
     """ Reconfiguration of a Stream """
     name: str
-    user: Optional[str]
-    password: Optional[str]
-    station: Optional[str]
-    url: Optional[str]
-    logo: Optional[str]
-    freq: Optional[str]
+    user: Optional[str] = None
+    password: Optional[str] = None
+    station: Optional[str] = None
+    url: Optional[str] = None
+    logo: Optional[str] = None
+    freq: Optional[str] = None
 
 
 class StreamCommand(str, Enum):
@@ -142,9 +143,9 @@ class StreamCommand(str, Enum):
 
 class PresetState(BaseModel):
     """ A set of partial configuration changes to make to sources, zones, and groups """
-    sources: Optional[List[SourceUpdateWithId]]
-    zones: Optional[List[ZoneUpdateWithId]]
-    groups: Optional[List[GroupUpdateWithId]]
+    sources: Optional[List[SourceUpdateWithId]] = None
+    zones: Optional[List[ZoneUpdateWithId]] = None
+    groups: Optional[List[GroupUpdateWithId]] = None
 
 
 class Command(BaseModel):
@@ -154,17 +155,17 @@ class Command(BaseModel):
 
 
 class Preset(BaseModel):
-    id: Optional[int]
+    id: Optional[int] = None
     name: str
-    state: Optional[PresetState]
-    commands: Optional[List[Command]]
+    state: Optional[PresetState] = None
+    commands: Optional[List[Command]] = None
     last_used: Union[int, None] = None
 
 
 class PresetUpdate(BaseModel):
-    name: Optional[str]
-    state: Optional[PresetState]
-    commands: Optional[List[Command]]
+    name: Optional[str] = None
+    state: Optional[PresetState] = None
+    commands: Optional[List[Command]] = None
 
 
 class Announcement(BaseModel):
@@ -178,15 +179,15 @@ class Announcement(BaseModel):
 
 class PlayMedia(BaseModel):
     media: str
-    vol: Optional[int]
-    vol_f: Optional[float]
-    source_id: Optional[int]
+    vol: Optional[int] = None
+    vol_f: Optional[float] = None
+    source_id: Optional[int] = None
 
 
 class FirmwareInfo(BaseModel):
-    version: Optional[str]
-    git_hash: Optional[str]
-    git_dirty: Optional[bool]
+    version: Optional[str] = None
+    git_hash: Optional[str] = None
+    git_dirty: Optional[bool] = None
 
 
 class Info(BaseModel):
@@ -195,8 +196,8 @@ class Info(BaseModel):
     mock_ctrl: bool = False
     mock_streams: bool = False
     online: Optional[bool] = True
-    latest_release: Optional[str]
-    fw: Optional[List[FirmwareInfo]]
+    latest_release: Optional[str] = None
+    fw: Optional[List[FirmwareInfo]] = None
 
 
 class Config(BaseModel):
@@ -208,7 +209,7 @@ class Config(BaseModel):
 
 
 class Status(Config):
-    info: Optional[Info]
+    info: Optional[Info] = None
 
 
 class AppSettings(BaseModel):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ setuptools>=60.5.0
 requests>=2.28.1
 urllib3>=1.26.7
 aiohttp>=3.8.1
-pydantic<2
+pydantic>=2.0
 argparse>=1.4.0
 python-dotenv>=0.21.0
 PyYAML>=6.0


### PR DESCRIPTION
Update to a newer generation of pydantic. Initial changes followed the guide here: https://docs.pydantic.dev/latest/migration/

The major challenge here was pyamplipi's use of pydantic;'s ModelMetaclass and ModelField which were made private by the pydantic devs (for good reasons).

This code has been tested via:
- upcoming automated tests in https://github.com/micro-nova/pyamplipi/tree/add-tests
- via manual cli testing with an inhouse amplipi running 0.4.5