### PR TITLE
Add Index to streams

### DIFF
--- a/pyamplipi/models.py
+++ b/pyamplipi/models.py
@@ -117,6 +117,14 @@ class Stream(BaseModel):
     freq: Optional[str] = None
     client_id: Optional[str] = None
     token: Optional[str] = None
+    server: Optional[str] = None
+    index: Optional[int] = None
+    disabled: Optional[bool] = False
+    ap2: Optional[bool] = None
+    port: Optional[int] = None
+    browsable: Optional[bool] = False
+    temporary: Optional[bool] = False
+    has_pause: Optional[bool] = False
 
 
 class StreamUpdate(BaseModel):


### PR DESCRIPTION
Streams were missing the optional value `index`, which is used by RCA streams to show what DAC they use